### PR TITLE
Komga - Stateful Form Addition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3669,9 +3669,9 @@
       },
       "dependencies": {
         "type": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
-          "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA=="
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.3.0.tgz",
+          "integrity": "sha512-rgPIqOdfK/4J9FhiVrZ3cveAjRRo5rsQBAIhnylX874y1DX/kEKSVdLsnuHB6l1KTjHyU01VjiMBHgU2adejyg=="
         }
       }
     },
@@ -5513,9 +5513,9 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
     },
     "just-debounce": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.0.0.tgz",
-      "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.1.0.tgz",
+      "integrity": "sha512-qpcRocdkUmf+UTNBYx5w6dexX5J31AKK1OmPwH630a83DdVVUIngk55RSAiIGpQyoH0dlr872VHfPjnQnK1qDQ=="
     },
     "keyv": {
       "version": "3.1.0",
@@ -6931,9 +6931,9 @@
       }
     },
     "paperback-extensions-common": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/paperback-extensions-common/-/paperback-extensions-common-2.1.9.tgz",
-      "integrity": "sha512-AD+C7sX0NjvXcWByenGxS9sLplGlITiQ5OyJztME32Ys13UnOWvznohA1NmV5XFS3+qyIibI+SiMHblgjnRaRA==",
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/paperback-extensions-common/-/paperback-extensions-common-2.1.17.tgz",
+      "integrity": "sha512-JWXRPkFjGPmS5tBi2knvVF2pZmJWxbLliObQB9Js7m8KBCMxgfHH57FwTjSYGXV3bFyGcSJhc0VubUuhHYa2TA==",
       "requires": {
         "axios": "^0.21.1",
         "browserify": "^17.0.0",
@@ -8014,9 +8014,9 @@
       }
     },
     "source-map-url": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
+      "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw=="
     },
     "sparkles": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "chai-as-promised": "^7.1.1",
     "cheerio": "^1.0.0-rc.5",
     "paperback-cli": "^1.2.5",
-    "paperback-extensions-common": "^2.1.9",
+    "paperback-extensions-common": "^2.1.17",
     "ts-mocha": "^7.0.0",
     "tsify": "^4.0.2",
     "typescript": "^3.9.6"

--- a/src/Komga/Komga.ts
+++ b/src/Komga/Komga.ts
@@ -11,7 +11,9 @@ import {
   PagedResults,
   SourceInfo,
   RequestHeaders,
-  TagSection
+  TagSection,
+  UserForm,
+  FormObject
 } from "paperback-extensions-common"
 
 const KOMGA_DOMAIN = 'https://demo.komga.org/api/v1'
@@ -322,5 +324,33 @@ export class Komga extends Source {
 
   getMangaShareUrl(mangaId: string) {
     return `${KOMGA_API_DOMAIN}/series/${mangaId}`
+  }
+
+  async getAppStatefulForm(): Promise<UserForm> {
+    
+    let objects: FormObject[] = []
+    
+    objects.push(createTextFieldObject({
+      id: 'serverAddress',
+      userReadableTitle: 'Server URL',
+      placeholderText: 'http://127.0.0.1:8080',
+      userResponse: await this.stateManager.retrieve('serverAddress')
+    }))
+
+    objects.push(createTextFieldObject({
+      id: 'serverUsername',
+      userReadableTitle: 'Username',
+      placeholderText: 'AnimeLover420',
+      userResponse: await this.stateManager.retrieve('serverUsername')
+    }))
+
+    objects.push(createTextFieldObject({
+      id: 'serverPassword',
+      userReadableTitle: 'Password',
+      placeholderText: 'Some Super Secret Password',
+      userResponse: await this.stateManager.retrieve('serverPassword')
+    }))
+
+    return createUserForm({formElements: objects})
   }
 }


### PR DESCRIPTION
- Updated Paperback-extensions-common to 2.1.17 - This is required for stateful support
- Added a user stateful form which lets the user fill out credentials/ip in-app

Please retrieve data as follows:
`let username = await this.stateManager.retrieve("serverUsername")`
`let address = await this.stateManager.retrieve("serverPassword")`
`let password = await this.stateManager.retrieve("serverAddress")`

Yes, they do need to be run in an async context. I might recommend retrieving the details in EVERY method.

If you want to run mocha tests and have this work, you can do something like the following: 

```typescript
describe("Komga Tests", function () {
  var wrapper: APIWrapper = new APIWrapper();
  var source: Source = new Komga(cheerio);
  var chai = require("chai"),
    expect = chai.expect;
  var chaiAsPromised = require("chai-as-promised");
  chai.use(chaiAsPromised);

  var mangaId = "some manga id here";

// THIS IS THE NEW BIT - By doing this, any retrieval done in your source should properly retrieve these values
  before(function() {
    // This will run before ANY test. Set your state values here
    source.stateManager.store("serverAddress", "192.168.0.9:8080") // Or whatever your endpoint is
    source.stateManager.store("serverUsername", "yourUsername")
    source.stateManager.store("serverPassword", "yourPassword")
  });

// ... The rest of the test class here
```